### PR TITLE
fix: Use UUID for idempotency key to scale to concurrent users

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -32486,6 +32486,7 @@ const exec = __importStar(__nccwpck_require__(5236));
 const github = __importStar(__nccwpck_require__(3228));
 const fs = __importStar(__nccwpck_require__(1943));
 const path = __importStar(__nccwpck_require__(6928));
+const crypto_1 = __nccwpck_require__(6982);
 const sdk_1 = __nccwpck_require__(6381);
 const dead_code_1 = __nccwpck_require__(1655);
 /** Fields that should be redacted from logs */
@@ -32579,9 +32580,8 @@ async function generateIdempotencyKey(workspacePath) {
     });
     const commitHash = output.trim();
     const repoName = path.basename(workspacePath);
-    // Add timestamp to ensure unique key per run (avoids 409 conflicts on re-runs)
-    const timestamp = Date.now();
-    return `${repoName}:deadcode:${commitHash}:${timestamp}`;
+    // Use UUID to ensure unique key per run (avoids 409 conflicts, scales to many concurrent users)
+    return `${repoName}:deadcode:${commitHash}:${(0, crypto_1.randomUUID)()}`;
 }
 async function run() {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as exec from '@actions/exec';
 import * as github from '@actions/github';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { Configuration, DefaultApi } from '@supermodeltools/sdk';
 import { findDeadCode, formatPrComment } from './dead-code';
 
@@ -112,10 +113,9 @@ async function generateIdempotencyKey(workspacePath: string): Promise<string> {
 
   const commitHash = output.trim();
   const repoName = path.basename(workspacePath);
-  // Add timestamp to ensure unique key per run (avoids 409 conflicts on re-runs)
-  const timestamp = Date.now();
 
-  return `${repoName}:deadcode:${commitHash}:${timestamp}`;
+  // Use UUID to ensure unique key per run (avoids 409 conflicts, scales to many concurrent users)
+  return `${repoName}:deadcode:${commitHash}:${randomUUID()}`;
 }
 
 async function run(): Promise<void> {


### PR DESCRIPTION
## Summary
Replace timestamp-based idempotency key with UUID to eliminate collision risk at scale.

## Problem
The previous timestamp-based key (`repoName:deadcode:commitHash:timestamp`) could theoretically collide if two users analyze the same repo at the same commit in the exact same millisecond.

## Solution
Use `crypto.randomUUID()` instead of `Date.now()`:
```typescript
return `${repoName}:deadcode:${commitHash}:${randomUUID()}`;
```

This guarantees uniqueness with zero collision risk, regardless of concurrent usage.

## Test plan
- [ ] Build succeeds
- [ ] Re-run workflow to verify no 409 conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated idempotency key generation to use UUID-based identification instead of timestamp-based approach for enhanced uniqueness and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->