### PR TITLE
fix: Read github-token from input instead of env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,18 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  dogfood:
+    name: Self-test (dogfood)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Dead Code Hunter on itself
+        uses: ./
+        with:
+          supermodel-api-key: ${{ secrets.SUPERMODEL_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -32621,7 +32621,7 @@ async function run() {
         core.setOutput('dead-code-json', JSON.stringify(deadCode));
         // Step 6: Post PR comment if enabled
         if (commentOnPr && github.context.payload.pull_request) {
-            const token = process.env.GITHUB_TOKEN;
+            const token = core.getInput('github-token') || process.env.GITHUB_TOKEN;
             if (token) {
                 const octokit = github.getOctokit(token);
                 const comment = (0, dead_code_1.formatPrComment)(deadCode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ async function run(): Promise<void> {
 
     // Step 6: Post PR comment if enabled
     if (commentOnPr && github.context.payload.pull_request) {
-      const token = process.env.GITHUB_TOKEN;
+      const token = core.getInput('github-token') || process.env.GITHUB_TOKEN;
       if (token) {
         const octokit = github.getOctokit(token);
         const comment = formatPrComment(deadCode);


### PR DESCRIPTION
## Summary
- Fix bug where GITHUB_TOKEN was read from `process.env` instead of `core.getInput('github-token')`
- This caused the warning "GITHUB_TOKEN not available, skipping PR comment" even when the token was provided as an input
- Add dogfood CI job to test the action on itself

## The Bug
```typescript
// Before (broken)
const token = process.env.GITHUB_TOKEN;

// After (fixed)
const token = core.getInput('github-token') || process.env.GITHUB_TOKEN;
```

## Test plan
- CI will run the dogfood job which tests the action on itself
- Should see PR comment posted (no more warning)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated self-testing workflow to validate tool functionality through continuous integration

* **Chores**
  * Improved GitHub authentication configuration for greater flexibility in specifying token inputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->