### PR TITLE
Add supermodeltools.com/trial CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If this is useful, please star our tools — it helps us grow:
 
 ### 1. Get an API key
 
-Sign up at [dashboard.supermodeltools.com](https://dashboard.supermodeltools.com) and create an API key.
+Start a free trial at [supermodeltools.com/trial](https://supermodeltools.com/trial) to get an API key.
 
 ### 2. Add the secret to your repository
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If this is useful, please star our tools — it helps us grow:
 
 ### 1. Get an API key
 
-Start a free trial at [supermodeltools.com/trial](https://supermodeltools.com/trial) to get an API key.
+**Save 40%+ on agent token costs — start free → [supermodeltools.com/trial](https://supermodeltools.com/trial)**
 
 ### 2. Add the secret to your repository
 


### PR DESCRIPTION
Adds the new `/trial` signup page link to the README so readers have a one-click path to start a free trial and get an API key.

Part of a coordinated set of PRs across the supermodeltools org adding `/trial` to each product's main user-facing surface.

Verified: https://supermodeltools.com/trial returns 200 (Pro $19/mo, Growth $199/mo, 14-day trial via Stripe).

Draft for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated the 'Get an API key' section in the README to direct users to `supermodeltools.com/trial` for starting a free trial and obtaining their API key. The remainder of the setup process, including API secret generation and configuration procedures, remains unchanged and continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->